### PR TITLE
No longer recommend to mount the var/cache

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -21,10 +21,10 @@ hooks:
         set -e
         bin/console assets:install --no-debug
         bin/console cache:clear
+        bin/console cache:warmup
     deploy: |
         set -e
         bin/console assets:install --symlink --relative public
-        bin/console cache:clear
 
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed
@@ -38,9 +38,6 @@ disk: 2048
 
 # The mounts that will be performed when the package is deployed.
 mounts:
-    "/var/cache":
-        source: local
-        source_path: "cache"
     "/var/log":
         source: local
         source_path: "log"


### PR DESCRIPTION
Hello,

One thing that really is annoying, is problem with Symfony cache, when it shouldn't be an issue when working with Symfony4+.

For now, your template suggests that you should mount the `/var/cache` so it can be writable. But not only, having it mounted, means it's shared between deployments.

```
mounts:
    "/var/cache":	
        source: local	
        source_path: "cache"
```

**Why is it bad to share symfony cache between deployments ?**

1/ Because you need to clear the cache 2 times. once in the `build` step and one in the `deploy` step.
If you ommit to do it in the `deploy` step, the application will use the cache from the previous deployment even if you cleared the cache in the `build` step.

2/ Clearing the cache both in the `build` and `deploy` is not reliable. When you are making big changes to your Symfony application, sometimes, Symfony loose the ability to remove the cache with the Symfony command because the application is no longer bootable. It's not that rare, and we all experienced it in dev. So I'm not sure we should suffer from it in a PaaS environment.
Exemple of a failure when clearing the cache with Symfony command.
![](https://user-images.githubusercontent.com/2103975/74661009-76025f80-5197-11ea-95aa-e57f9224350e.png)

The only workaround is to `rm -rf var/cache/*` which is bad.

### The solution:

**STOP** sharing the cache between deploys. Since Symfony4, as long as you're calling `bin/console cache:warmup` the application does not need to write anything by default in the cache folder.
See : https://symfony.com/doc/current/setup/file_permissions.html
